### PR TITLE
Fix artist name alignment when track name too long

### DIFF
--- a/spotui/src/TracksMenu.py
+++ b/spotui/src/TracksMenu.py
@@ -84,7 +84,6 @@ class TracksMenu(Component):
 
     def __pad_track_text(self, text, max_word_length):
         spaces_needed = max_word_length - len(text)
-        if spaces_needed > 0:
-            for i in range(0, spaces_needed + 1):
-                text += " "
+        for i in range(0, spaces_needed + 1):
+            text += " "
         return text

--- a/spotui/src/TracksMenu.py
+++ b/spotui/src/TracksMenu.py
@@ -84,6 +84,7 @@ class TracksMenu(Component):
 
     def __pad_track_text(self, text, max_word_length):
         spaces_needed = max_word_length - len(text)
-        for i in range(0, spaces_needed + 1):
-            text += " "
+        if spaces_needed > 0:
+            for i in range(0, spaces_needed + 1):
+                text += " "
         return text

--- a/spotui/src/util.py
+++ b/spotui/src/util.py
@@ -2,7 +2,7 @@ import time
 
 
 def truncate(text, max_length):
-    return (text[:max_length - 2] + "..") if len(text) > max_length else text
+    return (text[:max_length - 3] + "..") if len(text) > max_length else text
 
 
 def ms_to_hms(ms):


### PR DESCRIPTION
Found a quick solution to issue #11.
The condition is not met when the song title is too long and has to be truncated.
This way, all songs titles are appended with at least one space.