### PR TITLE
.get_recently_played() function adapted to exclude duplicate tracks

### DIFF
--- a/spotui/src/spotifyApi.py
+++ b/spotui/src/spotifyApi.py
@@ -128,9 +128,14 @@ class SpotifyApi:
                 return []
             tracks = self.client.current_user_recently_played()
             items = tracks["items"]
+            # set used to identify unique tracks, prevent duplication of results
+            track_uris = set()
             while tracks["next"]:
                 tracks = self.client.next(tracks)
                 items += tracks["items"]
+                # remove all non-unique track-items from recently played list
+                items = [item for item in items if item["track"]["uri"] not in track_uris \
+                and (track_uris.add(item["track"]["uri"]) or True)]
             return list(map(self.__map_tracks, items))
         except Exception as e:
             pass


### PR DESCRIPTION

![spotui-recently-played-dup-on-2020-10-15](https://user-images.githubusercontent.com/46533567/96198455-c6aba180-0f4c-11eb-8f15-7e369e78e6a1.png)

Noticed that tracks were appearing multiple times as returned by the spotipy .current_user_recently_played() function.

I made a fix in the SpotifyApi class, but it could easily be reimplemented in LibraryMenu - __select_recent_tracks() function, or somewhere else for that matter. 

 