### PR TITLE
bugfix for searchdialog on main form breaking due to threading issue

### DIFF
--- a/spotui/src/MainForm.py
+++ b/spotui/src/MainForm.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import curses
-from threading import Thread
+from threading import Thread, Lock
 from spotui.src.util import debounce
 from spotui.src.Logging import logging
 from spotui.src.spotifyApi import SpotifyApi
@@ -13,7 +13,7 @@ from spotui.src.SearchInput import SearchInput
 from spotui.src.NowPlaying import NowPlaying
 
 starttime = time.time()
-
+lock = Lock()
 
 class MainForm:
     def __init__(self, stdscr):
@@ -113,10 +113,14 @@ class MainForm:
 
     def status_loop(self):
         while 1:
-            if not self.pause_updates:
+
+            if not self.pause_updates:                
                 self.status = self.api.get_playing()
                 self.components[0].refresh_now_playing(self.status)
-                self.render()
+
+            with lock:
+                if not self.pause_updates:
+                    self.render()
             time.sleep(1 - ((time.time() - starttime) % 1))
 
     def render(self):


### PR DESCRIPTION
Hi ceuk. I've been looking at issue #14  today. 

I've determined that this is happening as a result of a threading issue (which is part of the reason why it's occasional, and rather difficult to consistently reproduce the behavior).

I've found that the curses input is occasionally being run twice. First in the main thread, where it is supposed to, and unintentionally in the daemon status_loop thread. See bellow: 

![two_thread_inputs](https://user-images.githubusercontent.com/46533567/112564355-06679680-8dd3-11eb-9699-a16c29c6a5eb.png)

What is presumably happening is that the condition **not pause_updates** is met in the status loop, a context switch happens, the main thread resumes, sets **pause_updates** to true, activates the search dialog, when the status_loop thread resumes (considering the condition has been met) it renders dialog again and thus two inputs are active. 

![satus_loop_show_search_bar](https://user-images.githubusercontent.com/46533567/112569005-54809800-8ddb-11eb-83eb-083cb64c6c88.png)

The fix might be what you want. I've tested it a bit and it seems to work OK. I've separated out the api call, since its non-critical and might take longer to run, from the thread lock section since it would likely inhibit performance.